### PR TITLE
liens vers la page configurationHomebridgeTypeGenerique.asciidoc

### DIFF
--- a/doc/fr_FR/configurationHomebridge.asciidoc
+++ b/doc/fr_FR/configurationHomebridge.asciidoc
@@ -59,7 +59,8 @@ En cliquant sur l'équipement, les types génériques utilisés pour la communic
 
 image::../images/typegen-1.png[]
 
-La majorité des types génériques est déjà renseignée. Dans certains cas, une configuration manuelle sera nécessaire (pour le plugin Virtuel par exemple).
+La majorité des types génériques est déjà renseignée. Dans certains cas, une configuration manuelle sera nécessaire (pour le plugin Virtuel par exemple). Le détail de la configuration de chaque type générique est accessible ici:
+include::configurationHomebridgeTypeGenerique.asciidoc[]
 
 Voici les types génériques disponibles : 
 
@@ -71,7 +72,6 @@ Pour les actions :
 
 image::../images/ypegeaction.png[]
 
-include::configurationHomebridgeTypeGenerique.asciidoc[]
 
 *Des exemples de configurations sont disponibles à la fin de la documentation*
 


### PR DESCRIPTION
J'ai mis un peu plus en avant le lien vers cette page fort intéressante dans la doc ;-)
D'ailleurs, il pourrait être utile de mettre le lien sur l'index de la doc également, dans "Exemple de configuration"?!
Car je n'ai pas relu toute la doc ce matin et je n'ai lu que ce qui était accessible à partir de l'index, page sur laquelle on arrive après avoir cliqué sur ? dans Jeedom.